### PR TITLE
Fix for file drag and drop.

### DIFF
--- a/arageno/templates/upload_genotype.html
+++ b/arageno/templates/upload_genotype.html
@@ -134,6 +134,7 @@
             resultText.innerText='The file ' + files[0].name+' is '+ (isValid ? 'valid': 'invalid');
             if (isValid) {
                 submitBtn.removeAttribute('disabled');
+                dropZoneEle.children.genotype_file.files = files
             }
         }
         dropZoneEle.style='display:'+ (hasFiles ? 'none' : 'block');


### PR DESCRIPTION
The file list is a child of the drop event, rather than than dropzone itself. Added one line to explicitly set genotype_file.files to the actual file list after checking that file is valid. 